### PR TITLE
Version 1.0.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /.tox
 /venv*
 /.venv/*
+experiments.py

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+    
+        {
+            "name": "Python Debugger: Current File",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "${file}",
+            "console": "integratedTerminal"
+        }
+    ]
+}

--- a/experiments.py
+++ b/experiments.py
@@ -1,7 +1,0 @@
-# future-tstrings
-
-pi = 3.14
-fmt = '<3'
-t = t"hello {pi}"
-
-print(t)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "future-tstrings"
-version = "1.0.0"
+version = "1.0.1"
 description = "Backport of tstrings to python <3.14, and full-syntax fstrings to python <3.12"
 readme = "README.md"
 authors = [{ name = "Marckie Zeender", email = "mkzeender@gmail.com" }]

--- a/src/future_tstrings/parser/compiler/ast.py
+++ b/src/future_tstrings/parser/compiler/ast.py
@@ -89,30 +89,36 @@ class CstToAstCompiler:
             for i, child in enumerate(node.children):
                 node.children[i] = self.visit(child)
         return node
+    
+    def _find_error_leaf(self, node: CstNodeOrLeaf|None) -> CstErrorLeaf|None:
+
+        if isinstance(node, CstErrorLeaf) or node is None:
+            return node
+        for child in getattr(node, "children", ()):
+            if leaf := self._find_error_leaf(child):
+                return leaf
+            
+        return None
+
 
     def generic_error(
         self, node: CstNodeOrLeaf, msg=None, **position: Unpack[OptionalPosDict]
     ) -> Never:
         if isinstance(node, (CstErrorNode, CstErrorLeaf)):
-            child: CstNodeOrLeaf = node
-            while children := getattr(child, "children", None):
-                for child in children:
-                    if isinstance(child, (CstErrorNode, CstErrorLeaf)):
-                        break
-                else:
-                    child = node
-                    break
-            if not isinstance(child, (CstErrorLeaf, CstErrorNode)):
-                bad_child = child.get_next_leaf()
+            
+            if (bad_child := self._find_error_leaf(node)) is None and (bad_child := self._find_error_leaf(node.get_next_sibling())) is None:
+                
+                bad_child = node
+                msg = 'Invalid Syntax.'
+                bad_child.get_next_sibling()
             else:
-                bad_child = child
-            msg = f"""{
-                repr(
-                    bad_child.get_code(include_prefix=False)
-                    if bad_child is not None
-                    else "EOF"
-                )
-            } is not understood here."""
+                msg = f"""{
+                    repr(
+                        bad_child.get_code(include_prefix=False)
+                        if bad_child is not None
+                        else "EOF"
+                    )
+                } is not understood here."""
             if bad_child is not node and bad_child is not None:
                 self.generic_error(bad_child, msg=msg)
 

--- a/src/future_tstrings/parser/compiler/ast.py
+++ b/src/future_tstrings/parser/compiler/ast.py
@@ -36,8 +36,7 @@ from .positions import (
     position_of,
 )
 
-if False: # TYPE_CHECKING
-    from typing import Never, Unpack
+from typing import Never, Unpack
 
 
 def _compile_with_offset(
@@ -196,6 +195,8 @@ class CstToAstCompiler:
 
                     eq_text: str = expr_node.get_code() + child.get_code() + suffix  # type: ignore
                     yield ast.Constant(value=eq_text, **position_of(child))
+                elif child.value not in ('}', ':', '!'):
+                    expr_node = child
             elif isinstance(child, CstNode) and child.type == "fstring_conversion":
                 conversion = ast.Constant(child.children[1].value, **position_of(child))  # type: ignore
             elif isinstance(child, CstNode) and child.type == "fstring_format_spec":

--- a/src/future_tstrings/parser/compiler/ast.py
+++ b/src/future_tstrings/parser/compiler/ast.py
@@ -35,8 +35,10 @@ from .positions import (
     PosTuple,
     position_of,
 )
-
-from typing import Never, Unpack
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    # not available in later versions
+    from typing import Never, Unpack
 
 
 def _compile_with_offset(

--- a/tests/_from_pep.py
+++ b/tests/_from_pep.py
@@ -1,4 +1,4 @@
-# future_tstrings
+# future-tstrings
 
 
 def test_creation():
@@ -46,3 +46,17 @@ def test_nested_tstring():
     template = t"Value: {t'hello {world}'}"
 
     assert template.interpolations[0].value.interpolations[0].value == world
+
+def test_literals():
+    template = t"Value: {...}, {...!r}"
+
+    assert template.interpolations[0].value is ...
+    assert template.interpolations[0].value is ...
+
+    template = t"Value: {None}, {1}, { {} }"
+
+    i = template.interpolations
+
+    assert i[0].value is None
+    assert i[1].value == 1
+    assert i[2].value == {}

--- a/uv.lock
+++ b/uv.lock
@@ -29,7 +29,7 @@ wheels = [
 
 [[package]]
 name = "future-tstrings"
-version = "1.0.0"
+version = "1.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "parso", marker = "python_full_version < '3.14'" },


### PR DESCRIPTION
Fix parsing of bare ```{...}``` (ellipsis literal) inside of a template string.

Improve syntax error messages for unexpected tokens.